### PR TITLE
refactor: centralize layout and styles

### DIFF
--- a/layout.php
+++ b/layout.php
@@ -1,0 +1,35 @@
+<?php
+function layout_header(string $title): void {
+?>
+<!doctype html>
+<html lang="de">
+<head>
+  <meta charset="utf-8">
+  <title><?= htmlspecialchars($title, ENT_QUOTES, 'UTF-8') ?></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <h1>HSN Kleiderkammer</h1>
+  </header>
+  <div class="layout">
+    <nav>
+      <ul>
+        <li><a href="index.html">Home</a></li>
+        <li><a href="materials.php">Materialien</a></li>
+      </ul>
+    </nav>
+    <main>
+<?php
+}
+
+function layout_footer(): void {
+?>
+    </main>
+  </div>
+</body>
+</html>
+<?php
+}
+?>

--- a/materials.php
+++ b/materials.php
@@ -142,44 +142,11 @@ $rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 /* ========= UI ========= */
 $flashSuccess = flash('success');
+
+require __DIR__.'/layout.php';
+layout_header('Materialien – Übersicht & Anlage');
 ?>
-<!doctype html>
-<html lang="de">
-<head>
-  <meta charset="utf-8">
-  <title>Materialien – Übersicht & Anlage</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style>
-    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;line-height:1.35;margin:2rem;background:#f7f7f8}
-    .layout{display:grid;grid-template-columns:2.2fr 1fr;gap:20px;align-items:start}
-    @media (max-width:1100px){.layout{grid-template-columns:1fr}}
-    .card{background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:18px;box-shadow:0 1px 20px rgba(0,0,0,.04)}
-    h1{margin:.2rem 0 1rem 0;font-size:1.4rem}
-    h2{margin:.2rem 0 1rem 0;font-size:1.15rem}
-    .filters{display:grid;grid-template-columns:1.2fr 1fr 1fr .7fr auto;gap:10px;margin-bottom:12px}
-    label{font-weight:600;font-size:.9rem;margin-bottom:.2rem;display:block}
-    input[type=text], select, textarea{width:100%;padding:.5rem .6rem;border:1px solid #d1d5db;border-radius:8px;background:#fff}
-    table{width:100%;border-collapse:collapse}
-    th,td{padding:.55rem .6rem;border-bottom:1px solid #e5e7eb;text-align:left;font-size:.95rem}
-    th{background:#f9fafb}
-    .muted{color:#6b7280}
-    .pill{display:inline-block;padding:.05rem .5rem;border-radius:999px;font-size:.78rem;border:1px solid #d1d5db}
-    .pill.on{background:#ecfdf5;color:#065f46;border-color:#a7f3d0}
-    .pill.off{background:#fef2f2;color:#991b1b;border-color:#fecaca}
-    .pagination{display:flex;gap:6px;align-items:center;margin-top:10px}
-    .btn{appearance:none;border:0;border-radius:10px;padding:.55rem .8rem;font-weight:600;cursor:pointer}
-    .btn-primary{background:#111827;color:#fff}
-    .btn-secondary{background:#e5e7eb}
-    .hint{color:#6b7280;font-size:.88rem}
-    .alert{padding:.6rem .8rem;border-radius:8px;margin-bottom:12px}
-    .alert-success{background:#ecfdf5;border:1px solid #a7f3d0;color:#065f46}
-    .alert-error{background:#fef2f2;border:1px solid #fecaca;color:#991b1b}
-    .grid2{display:grid;grid-template-columns:1fr 1fr;gap:12px}
-    .grid1{display:grid;grid-template-columns:1fr;gap:12px}
-  </style>
-</head>
-<body>
-  <div class="layout">
+  <div class="split">
     <!-- Liste -->
     <div class="card">
       <h1>Materialien</h1>
@@ -357,5 +324,4 @@ $flashSuccess = flash('success');
       </div>
     </div>
   </div>
-</body>
-</html>
+<?php layout_footer(); ?>

--- a/style.css
+++ b/style.css
@@ -1,6 +1,8 @@
 body {
   margin: 0;
-  font-family: Arial, sans-serif;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+  line-height: 1.35;
+  background: #f7f7f8;
 }
 
 header {
@@ -100,3 +102,38 @@ legend {
 #positionen-tabelle td select {
   width: 100%;
 }
+
+/* Shared components moved from materials.php */
+.split{display:grid;grid-template-columns:2.2fr 1fr;gap:20px;align-items:start;}
+@media (max-width:1100px){.split{grid-template-columns:1fr;}}
+.card{background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:18px;box-shadow:0 1px 20px rgba(0,0,0,.04);}
+h1{margin:.2rem 0 1rem 0;font-size:1.4rem;}
+h2{margin:.2rem 0 1rem 0;font-size:1.15rem;}
+.filters{display:grid;grid-template-columns:1.2fr 1fr 1fr .7fr auto;gap:10px;margin-bottom:12px;}
+label{font-weight:600;font-size:.9rem;margin-bottom:.2rem;display:block;}
+input[type=text], select, textarea{width:100%;padding:.5rem .6rem;border:1px solid #d1d5db;border-radius:8px;background:#fff;}
+table{width:100%;border-collapse:collapse;}
+th,td{padding:.55rem .6rem;border-bottom:1px solid #e5e7eb;text-align:left;font-size:.95rem;}
+th{background:#f9fafb;}
+.muted{color:#6b7280;}
+.pill{display:inline-block;padding:.05rem .5rem;border-radius:999px;font-size:.78rem;border:1px solid #d1d5db;}
+.pill.on{background:#ecfdf5;color:#065f46;border-color:#a7f3d0;}
+.pill.off{background:#fef2f2;color:#991b1b;border-color:#fecaca;}
+.pagination{display:flex;gap:6px;align-items:center;margin-top:10px;}
+.btn{appearance:none;border:0;border-radius:10px;padding:.55rem .8rem;font-weight:600;cursor:pointer;}
+.btn-primary{background:#111827;color:#fff;}
+.btn-secondary{background:#e5e7eb;}
+.hint{color:#6b7280;font-size:.88rem;}
+.alert{padding:.6rem .8rem;border-radius:8px;margin-bottom:12px;}
+.alert-success{background:#ecfdf5;border:1px solid #a7f3d0;color:#065f46;}
+.alert-error{background:#fef2f2;border:1px solid #fecaca;color:#991b1b;}
+.grid2{display:grid;grid-template-columns:1fr 1fr;gap:12px;}
+.grid1{display:grid;grid-template-columns:1fr;gap:12px;}
+.row{display:grid;grid-template-columns:1fr 1fr;gap:16px;}
+.row-3{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;}
+.row-1{display:grid;grid-template-columns:1fr;gap:16px;}
+.field{margin-bottom:14px;}
+.subtitle{color:#4b5563;margin-bottom:1.2rem;}
+.error{color:#b91c1c;font-size:.9rem;margin-top:.2rem;}
+.badge{display:inline-block;background:#eef2ff;color:#3730a3;border-radius:999px;padding:.15rem .55rem;font-size:.78rem;margin-left:.35rem;}
+.actions{margin-top:12px;display:flex;gap:8px;align-items:center;}

--- a/variant_create.php
+++ b/variant_create.php
@@ -198,46 +198,10 @@ $existing->execute([':mid'=>$materialId]);
 $variants = $existing->fetchAll(PDO::FETCH_ASSOC);
 
 /* ====== UI ====== */
+
+require __DIR__.'/layout.php';
+layout_header('Variante anlegen – '.$material['MaterialName']);
 ?>
-<!doctype html>
-<html lang="de">
-<head>
-  <meta charset="utf-8">
-  <title>Variante anlegen – <?= e($material['MaterialName']) ?></title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <style>
-    body{font-family:system-ui,-apple-system,Segoe UI,Roboto,Helvetica,Arial,sans-serif;line-height:1.35;margin:2rem;background:#f7f7f8}
-    .card{max-width:980px;margin:0 auto;background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:24px;box-shadow:0 1px 20px rgba(0,0,0,.04)}
-    h1{margin:0 0 1rem 0;font-size:1.35rem}
-    .subtitle{color:#4b5563;margin-bottom:1.2rem}
-    .row{display:grid;grid-template-columns:1fr 1fr;gap:16px}
-    .row-3{display:grid;grid-template-columns:repeat(3,1fr);gap:16px}
-    .row-1{display:grid;grid-template-columns:1fr;gap:16px}
-    label{display:block;font-weight:600;margin:.2rem 0}
-    input[type=text], select, textarea{
-      width:100%;padding:.6rem .7rem;border:1px solid #d1d5db;border-radius:8px;font-size:1rem;background:#fff
-    }
-    textarea{min-height:80px}
-    .field{margin-bottom:14px}
-    .hint{color:#6b7280;font-size:.9rem}
-    .error{color:#b91c1c;font-size:.9rem;margin-top:.2rem}
-    .badge{display:inline-block;background:#eef2ff;color:#3730a3;border-radius:999px;padding:.15rem .55rem;font-size:.78rem;margin-left:.35rem}
-    .actions{margin-top:12px;display:flex;gap:8px;align-items:center}
-    .btn{appearance:none;border:0;border-radius:10px;padding:.7rem 1rem;font-weight:600;cursor:pointer}
-    .btn-primary{background:#111827;color:#fff}
-    .btn-secondary{background:#e5e7eb}
-    table{width:100%;border-collapse:collapse;margin-top:18px}
-    th,td{padding:.55rem .6rem;border-bottom:1px solid #e5e7eb;text-align:left;font-size:.95rem}
-    th{background:#f9fafb}
-    .pill{display:inline-block;padding:.05rem .5rem;border-radius:999px;font-size:.78rem;border:1px solid #d1d5db}
-    .pill.on{background:#ecfdf5;color:#065f46;border-color:#a7f3d0}
-    .pill.off{background:#fef2f2;color:#991b1b;border-color:#fecaca}
-    .alert{padding:.6rem .8rem;border-radius:8px;margin-bottom:12px}
-    .alert-success{background:#ecfdf5;border:1px solid #a7f3d0;color:#065f46}
-    .alert-error{background:#fef2f2;border:1px solid #fecaca;color:#991b1b}
-  </style>
-</head>
-<body>
   <div class="card">
     <h1>Variante anlegen</h1>
     <div class="subtitle">
@@ -381,5 +345,4 @@ $variants = $existing->fetchAll(PDO::FETCH_ASSOC);
       <a class="btn btn-secondary" href="materials_list.php">Zurück zur Materialliste</a>
     </div>
   </div>
-</body>
-</html>
+<?php layout_footer(); ?>

--- a/views/artikel.html
+++ b/views/artikel.html
@@ -1,5 +1,6 @@
+<div class="card">
 <h2>Artikelverwaltung</h2>
-<button onclick="openArtikelPopup()">➕ Artikel hinzufügen</button>
+<button class="btn btn-primary" onclick="openArtikelPopup()">➕ Artikel hinzufügen</button>
 
 <input type="text" id="artikel-suche" placeholder="🔍 Suche nach Bezeichnung oder Gruppe" />
 
@@ -14,6 +15,7 @@
   </thead>
   <tbody></tbody>
 </table>
+</div>
 
 <div id="artikel-popup" class="popup">
   <form id="artikel-form">
@@ -32,8 +34,8 @@
       <option>Diverses</option>
     </select>
     <div class="buttons">
-      <button type="submit">Speichern</button>
-      <button type="button" onclick="closeArtikelPopup()">Abbrechen</button>
+      <button class="btn btn-primary" type="submit">Speichern</button>
+      <button class="btn btn-secondary" type="button" onclick="closeArtikelPopup()">Abbrechen</button>
     </div>
   </form>
 </div>

--- a/views/ausgabe.html
+++ b/views/ausgabe.html
@@ -29,7 +29,7 @@
     <input type="hidden" name="unterschrift" id="unterschrift" />
 
     <div class="form-buttons">
-      <button type="button" class="btn btn-success" onclick="openSignaturePopup()">Kleidung ausgeben</button>
+      <button type="button" class="btn btn-primary" onclick="openSignaturePopup()">Kleidung ausgeben</button>
     </div>
   </form>
 </section>
@@ -41,7 +41,7 @@
     <canvas id="signature-pad" width="400" height="200" style="border:1px solid #ccc;"></canvas>
     <div class="form-buttons">
       <button class="btn btn-primary" onclick="confirmAusgabe()">✅ OK</button>
-      <button class="btn" onclick="closeSignaturePopup()">❌ Abbrechen</button>
+      <button class="btn btn-secondary" onclick="closeSignaturePopup()">❌ Abbrechen</button>
     </div>
   </div>
 </div>

--- a/views/ausgaben_mitarbeiter.html
+++ b/views/ausgaben_mitarbeiter.html
@@ -1,3 +1,4 @@
+<div class="card">
 <h2>Ausgaben pro Mitarbeiter</h2>
 <select id="mitarbeiter-filter">
   <option value="">Alle</option>
@@ -8,3 +9,4 @@
   </thead>
   <tbody></tbody>
 </table>
+</div>

--- a/views/bestaende.html
+++ b/views/bestaende.html
@@ -1,8 +1,9 @@
+<div class="card">
 <h2>Bestände verwalten</h2>
 
-<button onclick="window.location = 'api/export_bestaende_csv.php'">📥 Bestände als CSV exportieren</button>
+<button class="btn btn-primary" onclick="window.location = 'api/export_bestaende_csv.php'">📥 Bestände als CSV exportieren</button>
 
-<button onclick="createInventurliste()">📄 Inventurliste erstellen (A4)</button>
+<button class="btn btn-secondary" onclick="createInventurliste()">📄 Inventurliste erstellen (A4)</button>
 
 <table id="bestaende-tabelle">
   <thead>
@@ -16,6 +17,8 @@
   <tbody></tbody>
 </table>
 
+</div>
+
 <!-- Popup für Bestandskorrektur -->
 <div id="bestand-popup" class="popup">
   <form id="bestand-form">
@@ -25,8 +28,8 @@
     <label>Neuer Bestand:</label>
     <input type="number" name="neuer_bestand" min="0" required />
     <div class="buttons">
-      <button type="submit">Speichern</button>
-      <button type="button" onclick="closeBestandPopup()">Abbrechen</button>
+      <button class="btn btn-primary" type="submit">Speichern</button>
+      <button class="btn btn-secondary" type="button" onclick="closeBestandPopup()">Abbrechen</button>
     </div>
   </form>
 </div>

--- a/views/inventur.html
+++ b/views/inventur.html
@@ -1,3 +1,4 @@
+<div class="card">
 <h2>Inventur durchführen</h2>
 
 <form id="inventur-form">
@@ -14,5 +15,6 @@
     <tbody></tbody>
   </table>
 
-  <button type="submit">📊 Differenzen verbuchen</button>
+  <button class="btn btn-primary" type="submit">📊 Differenzen verbuchen</button>
 </form>
+</div>

--- a/views/mitarbeiter.html
+++ b/views/mitarbeiter.html
@@ -1,5 +1,6 @@
+<div class="card">
 <h2>Mitarbeiterverwaltung</h2>
-<button onclick="openMitarbeiterPopup()">➕ Mitarbeiter hinzufügen</button>
+<button class="btn btn-primary" onclick="openMitarbeiterPopup()">➕ Mitarbeiter hinzufügen</button>
 <input type="text" id="mitarbeiter-suche" placeholder="🔍 Suche nach Name, Abteilung..." />
 
 <table id="mitarbeiter-tabelle">
@@ -16,6 +17,7 @@
   </thead>
   <tbody></tbody>
 </table>
+</div>
 
 <div id="mitarbeiter-popup" class="popup">
   <form id="mitarbeiter-form">
@@ -40,8 +42,8 @@
       <option value="extern">Extern</option>
     </select>
     <div class="buttons">
-      <button type="submit">Speichern</button>
-      <button type="button" onclick="closeMitarbeiterPopup()">Abbrechen</button>
+      <button class="btn btn-primary" type="submit">Speichern</button>
+      <button class="btn btn-secondary" type="button" onclick="closeMitarbeiterPopup()">Abbrechen</button>
     </div>
   </form>
 </div>

--- a/views/reporting.html
+++ b/views/reporting.html
@@ -1,3 +1,4 @@
+<div class="card">
 <h2>Wareneingang‑Report</h2>
 <table id="reporting-tabelle">
   <thead>
@@ -11,3 +12,4 @@
   </thead>
   <tbody></tbody>
 </table>
+</div>

--- a/views/wareneingang.html
+++ b/views/wareneingang.html
@@ -1,3 +1,4 @@
+<div class="card">
 <h2>Wareneingang erfassen</h2>
 
 <form id="eingang-form">
@@ -22,8 +23,9 @@
       </thead>
       <tbody></tbody>
     </table>
-    <button type="button" onclick="addEingangsPosition()">➕ Position hinzufügen</button>
+    <button class="btn btn-secondary" type="button" onclick="addEingangsPosition()">➕ Position hinzufügen</button>
   </fieldset>
 
-  <button type="submit">💾 Wareneingang buchen</button>
+  <button class="btn btn-primary" type="submit">💾 Wareneingang buchen</button>
 </form>
+</div>


### PR DESCRIPTION
## Summary
- move inline material styles into global stylesheet and add reusable components
- extract header/sidebar layout into PHP template
- update pages to use shared layout and button/card classes

## Testing
- `php -l materials.php`
- `php -l variant_create.php`
- `php -l layout.php`


------
https://chatgpt.com/codex/tasks/task_e_68af777181dc8323aa6a422819083118